### PR TITLE
fix: only disallow for null lists to not be sent

### DIFF
--- a/src/main/java/com/money/SaveMe/Controller/CategoryController.java
+++ b/src/main/java/com/money/SaveMe/Controller/CategoryController.java
@@ -23,7 +23,7 @@ public class CategoryController {
     public ResponseEntity<Iterable<CategoryDtoOut>> getAllCategories() {
         Iterable<Category> categories = categoryService.getAllCategories();
 
-        if (categories == null || !categories.iterator().hasNext()) {
+        if (categories == null) {
             return ResponseEntity.notFound().build();
         }
 

--- a/src/main/java/com/money/SaveMe/Controller/CurrencyController.java
+++ b/src/main/java/com/money/SaveMe/Controller/CurrencyController.java
@@ -24,6 +24,10 @@ public class CurrencyController {
     public ResponseEntity<List<CurrencyDtoOut>> getAllCurrencies() {
         Iterable<Currency> currencies = currencyService.getAllCurrenciesFromUser();
 
+        if(currencies == null){
+            return ResponseEntity.notFound().build();
+        }
+
         List<CurrencyDtoOut> currencyDtos = StreamSupport.stream(currencies.spliterator(),false).map(
                 currency -> new CurrencyDtoOut(
                         currency.getId(),

--- a/src/main/java/com/money/SaveMe/Controller/ExpenseController.java
+++ b/src/main/java/com/money/SaveMe/Controller/ExpenseController.java
@@ -23,7 +23,7 @@ public class ExpenseController {
     public ResponseEntity<Iterable<ExpenseOutDto>> getAllExpenses() {
         Iterable<Expense> expenses = expenseService.getAllExpenses();
 
-        if (expenses == null || !expenses.iterator().hasNext()) {
+        if (expenses == null) {
             return ResponseEntity.notFound().build();
         }
 

--- a/src/main/java/com/money/SaveMe/Controller/IncomeController.java
+++ b/src/main/java/com/money/SaveMe/Controller/IncomeController.java
@@ -28,7 +28,7 @@ public class IncomeController {
     public ResponseEntity<Iterable<IncomeOutputDto>> getAllIncomeByUserIdFromCurrency() {
         Iterable<Income> incomes = incomeService.getAllIncomeByUserId();
 
-        if (incomes == null || !incomes.iterator().hasNext()) {
+        if (incomes == null) {
             return ResponseEntity.notFound().build();
         }
 

--- a/src/main/java/com/money/SaveMe/Controller/InvestmentController.java
+++ b/src/main/java/com/money/SaveMe/Controller/InvestmentController.java
@@ -31,7 +31,7 @@ public class InvestmentController {
     public ResponseEntity<Iterable<InvestmentOutDto>> getAllInvestments() {
         Iterable<Investment> investments = investmentService.getAllInvestments();
 
-        if (investments == null || !investments.iterator().hasNext()) {
+        if (investments == null) {
             return ResponseEntity.notFound().build();
         }
 

--- a/src/main/java/com/money/SaveMe/Controller/ObjectiveController.java
+++ b/src/main/java/com/money/SaveMe/Controller/ObjectiveController.java
@@ -34,7 +34,7 @@ public class ObjectiveController {
     public ResponseEntity<Iterable<ObjectiveOutputDto>> getAllObjectiveByUserIdFromCurrency() {
         Iterable<Objective> objectives = objectiveService.getAllObjectives();
 
-        if (objectives == null || !objectives.iterator().hasNext()) {
+        if (objectives == null) {
             return ResponseEntity.notFound().build();
         }
 

--- a/src/main/java/com/money/SaveMe/Controller/StrategyTypeController.java
+++ b/src/main/java/com/money/SaveMe/Controller/StrategyTypeController.java
@@ -23,7 +23,7 @@ public class StrategyTypeController {
     public ResponseEntity<Iterable<StrategyTypeOutputDto>> GetAllStrategyTypes() {
         Iterable<StrategyType> strategyTypes = strategyTypeService.getAllStrategyTypes();
 
-        if (strategyTypes == null || !strategyTypes.iterator().hasNext()) {
+        if (strategyTypes == null) {
             return ResponseEntity.notFound().build();
         }
 

--- a/src/main/java/com/money/SaveMe/Controller/WishController.java
+++ b/src/main/java/com/money/SaveMe/Controller/WishController.java
@@ -28,7 +28,7 @@ public class WishController {
     public ResponseEntity<Iterable<WishOutputDto>> getAllWishes(){
         Iterable<Wish> wishes = wishService.getAllWishes();
 
-        if (wishes == null || !wishes.iterator().hasNext()) {
+        if (wishes == null) {
             return ResponseEntity.notFound().build();
         }
 


### PR DESCRIPTION
# ✨ Fix: Allow empty list to pass in java controllers

Pages would not load when empty lists were given, simply because the api is returning an error when a list from the /all routes are returned from the service.

## 📝 Summary
Allow empty lists to be returned

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

## ✅ Checklist
<!-- Check all that apply -->
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [ ] Code is commented, particularly hard-to-understand areas
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] All tests pass
- [ ] Changelog updated

---

**📋 Merge Checklist:**
- [x] Code review completed
- [ ] All tests passing
- [x] Ready for deployment
